### PR TITLE
Added check for middle click to close active tab only in current window

### DIFF
--- a/src/middleClick.js
+++ b/src/middleClick.js
@@ -18,7 +18,7 @@ async function registerToTST() {
 
 async function middleclickHandler(message) {
     async function closeActiveTabs() {
-        let activeTabs = await browser.tabs.query({ active: true });
+        let activeTabs = await browser.tabs.query({ active: true, currentWindow: true });
 
         for (let tab of activeTabs) {
             browser.tabs.remove(tab.id);


### PR DESCRIPTION
Without the check, middle click on empty space closes active tab in all browser windows.
`currentWindow` paramater grabbed from documentation [here](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/query), so perhaps should work fine.